### PR TITLE
Fix tests by adding example project path

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,9 @@
+import os
+import sys
+from pathlib import Path
+
+ROOT_DIR = Path(__file__).resolve().parent
+sys.path.insert(0, str(ROOT_DIR))
+sys.path.insert(0, str(ROOT_DIR / "example_project" / "src"))
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "example_project.settings")

--- a/example_project/__init__.py
+++ b/example_project/__init__.py
@@ -1,0 +1,8 @@
+from pkgutil import extend_path
+from pathlib import Path
+
+__path__ = extend_path(__path__, __name__)
+# Include the source folder so that `example_project.settings` can be imported
+_src_pkg = Path(__file__).resolve().parent / 'src' / 'example_project'
+if str(_src_pkg) not in __path__:
+    __path__.append(str(_src_pkg))


### PR DESCRIPTION
## Summary
- ensure Django example project is importable without installation
- add root-level `conftest.py` to modify `sys.path`
- add package initializer that exposes example project from its `src` folder

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6859d12b2a60832299a0f88b14f61459