### PR TITLE
Remove redundant test settings

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,3 @@
 [pytest]
 DJANGO_SETTINGS_MODULE = example_project.settings
-addopts = --ds=example_project.settings
 python_files = tests/*.py

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,0 @@
-import os
-
-os.environ.setdefault(
-    "DJANGO_SETTINGS_MODULE",
-    "example_project.settings",
-)


### PR DESCRIPTION
## Summary
- clean up pytest.ini settings
- drop old test environment setup

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6859d43908508322b4374035b76eca67