### PR TITLE
Improve docs and add RemoteObject customization

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,5 +64,7 @@ pip install -e example_project
 ruff check .
 flake8
 pytest -q
+# Run Django's contenttypes tests as shipped in `dj_tests/`
+python dj_tests/runtests.py contenttypes_tests
 ```
 

--- a/example_project/src/example_project/testapp/models.py
+++ b/example_project/src/example_project/testapp/models.py
@@ -4,10 +4,13 @@ from federated_foreign_key.models import GenericContentType
 
 
 class Book(models.Model):
+    """Sample model used for tests."""
+
     title = models.CharField(max_length=50)
 
 
 class Reference(models.Model):
+    """Model holding a federated relation to any object."""
     content_type = models.ForeignKey(
         GenericContentType,
         on_delete=models.CASCADE,

--- a/federated_foreign_key/__init__.py
+++ b/federated_foreign_key/__init__.py
@@ -5,6 +5,7 @@ DEFAULT_APP_CONFIG = "federated_foreign_key.apps.FederatedForeignKeyConfig"
 __all__ = [
     "FederatedForeignKey",
     "RemoteObject",
+    "get_remote_object_class",
     "GenericContentType",
     "get_current_project_name",
 ]
@@ -12,7 +13,7 @@ __all__ = [
 
 def __getattr__(name):
     if name in __all__:
-        if name in ["FederatedForeignKey", "RemoteObject"]:
+        if name in ["FederatedForeignKey", "RemoteObject", "get_remote_object_class"]:
             module_name = "federated_foreign_key.fields"
         else:
             module_name = "federated_foreign_key.models"

--- a/federated_foreign_key/apps.py
+++ b/federated_foreign_key/apps.py
@@ -5,6 +5,8 @@ from .management.create import create_generic_contenttypes
 
 
 class FederatedForeignKeyConfig(AppConfig):
+    """Register signals to create ``GenericContentType`` objects."""
+
     name = "federated_foreign_key"
     verbose_name = "Federated Foreign Key"
 

--- a/federated_foreign_key/fields.py
+++ b/federated_foreign_key/fields.py
@@ -1,11 +1,27 @@
+from django.conf import settings
 from django.db.models.fields.mixins import FieldCacheMixin
 from django.core.exceptions import ObjectDoesNotExist
 from django.db.models import Field
+from django.utils.module_loading import import_string
 
 from .models import GenericContentType, get_current_project_name
 
+REMOTE_OBJECT_CLASS_SETTING = "FEDERATED_REMOTE_OBJECT_CLASS"
+
+
+def get_remote_object_class():
+    """Return the class used for remote objects."""
+    path = getattr(
+        settings,
+        REMOTE_OBJECT_CLASS_SETTING,
+        "federated_foreign_key.fields.RemoteObject",
+    )
+    return import_string(path)
+
 
 class RemoteObject:
+    """Placeholder for objects that live in another project."""
+
     def __init__(self, content_type, object_id):
         self.content_type = content_type
         self.object_id = object_id
@@ -15,6 +31,7 @@ class RemoteObject:
 
 
 class FederatedForeignKey(FieldCacheMixin, Field):
+    """A GenericForeignKey variant aware of project boundaries."""
     def __init__(
         self,
         ct_field="content_type",
@@ -77,7 +94,7 @@ class FederatedForeignKey(FieldCacheMixin, Field):
                 except (ObjectDoesNotExist, LookupError):
                     rel_obj = None
             else:
-                rel_obj = RemoteObject(ct, pk_val)
+                rel_obj = get_remote_object_class()(ct, pk_val)
         self.set_cached_value(instance, rel_obj)
         return rel_obj
 

--- a/federated_foreign_key/models.py
+++ b/federated_foreign_key/models.py
@@ -6,10 +6,13 @@ PROJECT_SETTING_NAME = "FEDERATION_PROJECT_NAME"
 
 
 def get_current_project_name():
+    """Return the current project name used for federated lookups."""
     return getattr(settings, PROJECT_SETTING_NAME, "default")
 
 
 class GenericContentTypeManager(models.Manager):
+    """Manager storing ``GenericContentType`` objects per project."""
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self._cache = None
@@ -61,6 +64,8 @@ class GenericContentTypeManager(models.Manager):
 
 
 class GenericContentType(models.Model):
+    """Like Django's ``ContentType`` model but scoped by project."""
+
     project = models.CharField(max_length=100)
     app_label = models.CharField(max_length=100)
     model = models.CharField(max_length=100)

--- a/tests/test_federated_fk.py
+++ b/tests/test_federated_fk.py
@@ -1,9 +1,17 @@
 import pytest
 
 from federated_foreign_key.models import GenericContentType
+from federated_foreign_key.fields import RemoteObject
 from example_project.testapp.models import Book, Reference
 
 pytestmark = pytest.mark.django_db
+
+
+class ExtraRemoteObject(RemoteObject):
+    """Custom remote object used in tests."""
+
+    def extra(self):
+        return self.content_type.project
 
 
 def test_local_reference():
@@ -31,3 +39,21 @@ def test_remote_reference():
     assert isinstance(obj, RemoteObject)
     assert obj.object_id == 1
     assert obj.content_type.project == remote_project
+
+
+def test_custom_remote_object(settings):
+    settings.FEDERATED_REMOTE_OBJECT_CLASS = (
+        "tests.test_federated_fk.ExtraRemoteObject"
+    )
+    remote_project = "project_c"
+    ct = GenericContentType.objects.create(
+        project=remote_project,
+        app_label="testapp",
+        model="book",
+    )
+    ref = Reference.objects.create(content_type=ct, object_id=2)
+
+    obj = ref.content_object
+
+    assert isinstance(obj, ExtraRemoteObject)
+    assert obj.extra() == remote_project


### PR DESCRIPTION
## Summary
- document running the Django test suite
- give example models some docstrings
- document project classes
- allow overriding the RemoteObject class via FEDERATED_REMOTE_OBJECT_CLASS
- test custom RemoteObject usage

## Testing
- `ruff check .`
- `flake8`
- `pytest -q`
- `python dj_tests/runtests.py contenttypes_tests`

------
https://chatgpt.com/codex/tasks/task_e_685a1ca8f130832293c49b185167e1b9