### PR TITLE
Use library implementations in Django test suite

### DIFF
--- a/dj_tests/contenttypes_tests/models.py
+++ b/dj_tests/contenttypes_tests/models.py
@@ -1,8 +1,9 @@
 import uuid
 from urllib.parse import quote
 
-from django.contrib.contenttypes.fields import GenericForeignKey, GenericRelation
-from django.contrib.contenttypes.models import ContentType
+from django.contrib.contenttypes.fields import GenericRelation
+from federated_foreign_key.fields import FederatedForeignKey
+from federated_foreign_key.models import GenericContentType
 from django.contrib.sites.models import SiteManager
 from django.db import models
 
@@ -77,9 +78,9 @@ class Question(models.Model):
 
 class Answer(models.Model):
     text = models.CharField(max_length=200)
-    content_type = models.ForeignKey(ContentType, models.CASCADE)
+    content_type = models.ForeignKey(GenericContentType, models.CASCADE)
     object_id = models.PositiveIntegerField()
-    question = GenericForeignKey()
+    question = FederatedForeignKey()
 
     class Meta:
         order_with_respect_to = "question"
@@ -89,9 +90,9 @@ class Post(models.Model):
     """An ordered tag on an item."""
 
     title = models.CharField(max_length=200)
-    content_type = models.ForeignKey(ContentType, models.CASCADE, null=True)
+    content_type = models.ForeignKey(GenericContentType, models.CASCADE, null=True)
     object_id = models.PositiveIntegerField(null=True)
-    parent = GenericForeignKey()
+    parent = FederatedForeignKey()
     children = GenericRelation("Post")
 
     class Meta:

--- a/dj_tests/contenttypes_tests/test_checks.py
+++ b/dj_tests/contenttypes_tests/test_checks.py
@@ -1,8 +1,9 @@
 from unittest import mock
 
 from django.contrib.contenttypes.checks import check_model_name_lengths
-from django.contrib.contenttypes.fields import GenericForeignKey, GenericRelation
-from django.contrib.contenttypes.models import ContentType
+from django.contrib.contenttypes.fields import GenericRelation
+from federated_foreign_key.fields import FederatedForeignKey as GenericForeignKey
+from federated_foreign_key.models import GenericContentType as ContentType
 from django.core import checks
 from django.db import models
 from django.test import SimpleTestCase, override_settings

--- a/dj_tests/contenttypes_tests/test_checks.py
+++ b/dj_tests/contenttypes_tests/test_checks.py
@@ -43,7 +43,7 @@ class GenericForeignKeyTests(SimpleTestCase):
                     "'Model.content_type' is not a ForeignKey.",
                     hint=(
                         "GenericForeignKeys must use a ForeignKey to "
-                        "'contenttypes.ContentType' as the 'content_type' field."
+                        "'federated_foreign_key.GenericContentType' as the 'content_type' field."
                     ),
                     obj=Model.content_object,
                     id="contenttypes.E003",
@@ -64,10 +64,10 @@ class GenericForeignKeyTests(SimpleTestCase):
             [
                 checks.Error(
                     "'Model.content_type' is not a ForeignKey to "
-                    "'contenttypes.ContentType'.",
+                    "'federated_foreign_key.GenericContentType'.",
                     hint=(
                         "GenericForeignKeys must use a ForeignKey to "
-                        "'contenttypes.ContentType' as the 'content_type' field."
+                        "'federated_foreign_key.GenericContentType' as the 'content_type' field."
                     ),
                     obj=Model.content_object,
                     id="contenttypes.E004",

--- a/dj_tests/contenttypes_tests/test_fields.py
+++ b/dj_tests/contenttypes_tests/test_fields.py
@@ -1,6 +1,6 @@
 import json
 
-from django.contrib.contenttypes.fields import GenericForeignKey
+from federated_foreign_key.fields import FederatedForeignKey as GenericForeignKey
 from django.contrib.contenttypes.prefetch import GenericPrefetch
 from django.db import models
 from django.test import TestCase

--- a/dj_tests/contenttypes_tests/test_management.py
+++ b/dj_tests/contenttypes_tests/test_management.py
@@ -18,6 +18,7 @@ class RemoveStaleContentTypesTests(TestCase):
         "empty_models",
         "no_models",
         "django.contrib.contenttypes",
+        "federated_foreign_key",
     ]
 
     @classmethod

--- a/dj_tests/contenttypes_tests/test_management.py
+++ b/dj_tests/contenttypes_tests/test_management.py
@@ -2,7 +2,7 @@ from unittest import mock
 
 from django.apps.registry import Apps, apps
 from django.contrib.contenttypes import management as contenttypes_management
-from django.contrib.contenttypes.models import ContentType
+from federated_foreign_key.models import GenericContentType as ContentType
 from django.core.management import call_command
 from django.test import TestCase, modify_settings
 from django.test.utils import captured_stdout

--- a/dj_tests/contenttypes_tests/test_migrations.py
+++ b/dj_tests/contenttypes_tests/test_migrations.py
@@ -2,7 +2,7 @@ from importlib import import_module
 
 from django.apps import apps
 from django.contrib.auth.models import Permission
-from django.contrib.contenttypes.models import ContentType
+from federated_foreign_key.models import GenericContentType as ContentType
 from django.db import DEFAULT_DB_ALIAS, connections
 from django.test import TransactionTestCase
 

--- a/dj_tests/contenttypes_tests/test_migrations.py
+++ b/dj_tests/contenttypes_tests/test_migrations.py
@@ -13,7 +13,7 @@ remove_content_type_name = import_module(
 
 class MultiDBRemoveContentTypeNameTests(TransactionTestCase):
     databases = {"default", "other"}
-    available_apps = ["django.contrib.auth", "django.contrib.contenttypes"]
+    available_apps = ["django.contrib.auth", "django.contrib.contenttypes", "federated_foreign_key"]
 
     def test_add_legacy_name_other_database(self):
         # add_legacy_name() should update ContentType objects in the specified

--- a/dj_tests/contenttypes_tests/test_models.py
+++ b/dj_tests/contenttypes_tests/test_models.py
@@ -1,5 +1,8 @@
 from django.apps import apps
-from django.contrib.contenttypes.models import ContentType, ContentTypeManager
+from federated_foreign_key.models import (
+    GenericContentType as ContentType,
+    GenericContentTypeManager as ContentTypeManager,
+)
 from django.contrib.contenttypes.prefetch import GenericPrefetch
 from django.db import models
 from django.db.migrations.state import ModelState, ProjectState

--- a/dj_tests/contenttypes_tests/test_models.py
+++ b/dj_tests/contenttypes_tests/test_models.py
@@ -34,7 +34,7 @@ class ContentTypesTests(TestCase):
         with self.assertNumQueries(0):
             ContentType.objects.get_for_id(ct.id)
         with self.assertNumQueries(0):
-            ContentType.objects.get_by_natural_key("contenttypes", "contenttype")
+            ContentType.objects.get_by_natural_key("default", "contenttypes", "contenttype")
 
         # Once we clear the cache, another lookup will again hit the DB
         ContentType.objects.clear_cache()
@@ -44,10 +44,10 @@ class ContentTypesTests(TestCase):
         # The same should happen with a lookup by natural key
         ContentType.objects.clear_cache()
         with self.assertNumQueries(1):
-            ContentType.objects.get_by_natural_key("contenttypes", "contenttype")
+            ContentType.objects.get_by_natural_key("default", "contenttypes", "contenttype")
         # And a second hit shouldn't hit the DB
         with self.assertNumQueries(0):
-            ContentType.objects.get_by_natural_key("contenttypes", "contenttype")
+            ContentType.objects.get_by_natural_key("default", "contenttypes", "contenttype")
 
     def test_get_for_models_creation(self):
         ContentType.objects.all().delete()

--- a/dj_tests/contenttypes_tests/test_operations.py
+++ b/dj_tests/contenttypes_tests/test_operations.py
@@ -18,6 +18,7 @@ class ContentTypeOperationsTests(TransactionTestCase):
     available_apps = [
         "contenttypes_tests",
         "django.contrib.contenttypes",
+        "federated_foreign_key",
     ]
 
     class TestRouter:

--- a/dj_tests/contenttypes_tests/test_operations.py
+++ b/dj_tests/contenttypes_tests/test_operations.py
@@ -1,7 +1,7 @@
 from django.apps.registry import apps
 from django.conf import settings
 from django.contrib.contenttypes import management as contenttypes_management
-from django.contrib.contenttypes.models import ContentType
+from federated_foreign_key.models import GenericContentType as ContentType
 from django.core.management import call_command
 from django.db import migrations, models
 from django.test import TransactionTestCase, override_settings

--- a/dj_tests/contenttypes_tests/test_views.py
+++ b/dj_tests/contenttypes_tests/test_views.py
@@ -2,7 +2,7 @@ import datetime
 from unittest import mock
 import django
 
-from django.contrib.contenttypes.models import ContentType
+from federated_foreign_key.models import GenericContentType as ContentType
 from django.contrib.contenttypes.views import shortcut
 from django.contrib.sites.models import Site
 from django.contrib.sites.shortcuts import get_current_site

--- a/dj_tests/runtests.py
+++ b/dj_tests/runtests.py
@@ -34,7 +34,10 @@ except ImportError:  # Django < 6.1
     from django.utils.deprecation import RemovedInDjango51Warning as RemovedInDjango61Warning
 from django.utils.functional import classproperty
 from django.utils.log import DEFAULT_LOGGING
-from django.utils.version import PYPY
+try:
+    from django.utils.version import PYPY
+except ImportError:  # Django >= 5.0 removed this constant
+    PYPY = False
 
 
 try:

--- a/dj_tests/runtests.py
+++ b/dj_tests/runtests.py
@@ -28,12 +28,13 @@ else:
     from django.test.runner import get_max_test_processes, parallel_type
     from django.test.selenium import SeleniumTestCase, SeleniumTestCaseBase
     from django.test.utils import NullTimeKeeper, TimeKeeper, get_runner
-    from django.utils.deprecation import (
-        RemovedInDjango61Warning,
-    )
-    from django.utils.functional import classproperty
-    from django.utils.log import DEFAULT_LOGGING
-    from django.utils.version import PYPY
+try:
+    from django.utils.deprecation import RemovedInDjango61Warning
+except ImportError:  # Django < 6.1
+    from django.utils.deprecation import RemovedInDjango51Warning as RemovedInDjango61Warning
+from django.utils.functional import classproperty
+from django.utils.log import DEFAULT_LOGGING
+from django.utils.version import PYPY
 
 
 try:
@@ -86,6 +87,7 @@ SUBDIRS_TO_SKIP = {
 
 ALWAYS_INSTALLED_APPS = [
     "django.contrib.contenttypes",
+    "federated_foreign_key",
     "django.contrib.auth",
     "django.contrib.sites",
     "django.contrib.sessions",

--- a/federated_foreign_key/fields.py
+++ b/federated_foreign_key/fields.py
@@ -59,7 +59,9 @@ class FederatedForeignKey(DjangoGenericForeignKey):
                     checks.Error(
                         "'%s.%s' is not a ForeignKey." % (self.model._meta.object_name, self.ct_field),
                         hint=(
-                            "GenericForeignKeys must use a ForeignKey to 'federated_foreign_key.GenericContentType' as the 'content_type' field."
+                            "GenericForeignKeys must use a ForeignKey to "
+                            "'federated_foreign_key.GenericContentType' as the "
+                            "'content_type' field."
                         ),
                         obj=self,
                         id="contenttypes.E003",
@@ -71,7 +73,9 @@ class FederatedForeignKey(DjangoGenericForeignKey):
                         "'%s.%s' is not a ForeignKey to 'federated_foreign_key.GenericContentType'."
                         % (self.model._meta.object_name, self.ct_field),
                         hint=(
-                            "GenericForeignKeys must use a ForeignKey to 'federated_foreign_key.GenericContentType' as the 'content_type' field."
+                            "GenericForeignKeys must use a ForeignKey to "
+                            "'federated_foreign_key.GenericContentType' as the "
+                            "'content_type' field."
                         ),
                         obj=self,
                         id="contenttypes.E004",
@@ -79,7 +83,6 @@ class FederatedForeignKey(DjangoGenericForeignKey):
                 ]
             else:
                 return []
-
 
     def get_content_type(self, obj=None, id=None, using=None, model=None):
         if obj is not None:
@@ -118,4 +121,3 @@ class FederatedForeignKey(DjangoGenericForeignKey):
                 rel_obj = get_remote_object_class()(ct, pk_val)
         self.set_cached_value(instance, rel_obj)
         return rel_obj
-

--- a/federated_foreign_key/fields.py
+++ b/federated_foreign_key/fields.py
@@ -1,8 +1,9 @@
 from django.conf import settings
-from django.db.models.fields.mixins import FieldCacheMixin
-from django.core.exceptions import ObjectDoesNotExist
-from django.db.models import Field
+from django.core.exceptions import FieldDoesNotExist, ObjectDoesNotExist
+from django.core import checks
+from django.db import models
 from django.utils.module_loading import import_string
+from django.contrib.contenttypes.fields import GenericForeignKey as DjangoGenericForeignKey
 
 from .models import GenericContentType, get_current_project_name
 
@@ -30,7 +31,7 @@ class RemoteObject:
         return f"<RemoteObject {self.content_type} id={self.object_id}>"
 
 
-class FederatedForeignKey(FieldCacheMixin, Field):
+class FederatedForeignKey(DjangoGenericForeignKey):
     """A GenericForeignKey variant aware of project boundaries."""
     def __init__(
         self,
@@ -38,29 +39,49 @@ class FederatedForeignKey(FieldCacheMixin, Field):
         fk_field="object_id",
         for_concrete_model=True,
     ):
-        Field.__init__(self, editable=False)
-        FieldCacheMixin.__init__(self)
-        self.ct_field = ct_field
-        self.fk_field = fk_field
-        self.for_concrete_model = for_concrete_model
-        self.is_relation = True
+        super().__init__(ct_field=ct_field, fk_field=fk_field, for_concrete_model=for_concrete_model)
 
-    @property
-    def cache_name(self):
-        return self.name
+    def _check_content_type_field(self):
+        try:
+            field = self.model._meta.get_field(self.ct_field)
+        except FieldDoesNotExist:
+            return [
+                checks.Error(
+                    "The GenericForeignKey content type references the nonexistent field '%s.%s'."
+                    % (self.model._meta.object_name, self.ct_field),
+                    obj=self,
+                    id="contenttypes.E002",
+                )
+            ]
+        else:
+            if not isinstance(field, models.ForeignKey):
+                return [
+                    checks.Error(
+                        "'%s.%s' is not a ForeignKey." % (self.model._meta.object_name, self.ct_field),
+                        hint=(
+                            "GenericForeignKeys must use a ForeignKey to 'federated_foreign_key.GenericContentType' as the 'content_type' field."
+                        ),
+                        obj=self,
+                        id="contenttypes.E003",
+                    )
+                ]
+            elif field.remote_field.model != GenericContentType:
+                return [
+                    checks.Error(
+                        "'%s.%s' is not a ForeignKey to 'federated_foreign_key.GenericContentType'."
+                        % (self.model._meta.object_name, self.ct_field),
+                        hint=(
+                            "GenericForeignKeys must use a ForeignKey to 'federated_foreign_key.GenericContentType' as the 'content_type' field."
+                        ),
+                        obj=self,
+                        id="contenttypes.E004",
+                    )
+                ]
+            else:
+                return []
 
-    def get_cache_name(self):
-        return self.cache_name
 
-    def contribute_to_class(self, cls, name, **kwargs):
-        super().contribute_to_class(cls, name, private_only=True, **kwargs)
-        setattr(cls, self.attname, self)
-
-    def get_attname_column(self):
-        attname, column = super().get_attname_column()
-        return attname, None
-
-    def get_content_type(self, obj=None, id=None, model=None):
+    def get_content_type(self, obj=None, id=None, using=None, model=None):
         if obj is not None:
             return GenericContentType.objects.get_for_model(obj.__class__)
         elif id is not None:
@@ -98,13 +119,3 @@ class FederatedForeignKey(FieldCacheMixin, Field):
         self.set_cached_value(instance, rel_obj)
         return rel_obj
 
-    def __set__(self, instance, value):
-        if value is None:
-            setattr(instance, self.ct_field, None)
-            setattr(instance, self.fk_field, None)
-            self.set_cached_value(instance, None)
-            return
-        ct = self.get_content_type(obj=value)
-        setattr(instance, self.ct_field, ct)
-        setattr(instance, self.fk_field, value.pk)
-        self.set_cached_value(instance, value)

--- a/federated_foreign_key/models.py
+++ b/federated_foreign_key/models.py
@@ -1,6 +1,6 @@
 from django.conf import settings
 from django.apps import apps
-from django.db import models
+from django.db import models as django_models
 
 PROJECT_SETTING_NAME = "FEDERATION_PROJECT_NAME"
 
@@ -10,7 +10,7 @@ def get_current_project_name():
     return getattr(settings, PROJECT_SETTING_NAME, "default")
 
 
-class GenericContentTypeManager(models.Manager):
+class GenericContentTypeManager(django_models.Manager):
     """Manager storing ``GenericContentType`` objects per project."""
 
     def __init__(self, *args, **kwargs):
@@ -28,10 +28,13 @@ class GenericContentTypeManager(models.Manager):
     def clear_cache(self):
         self._cache = None
 
-    def get_for_model(self, model, project=None):
+    def _get_opts(self, model, for_concrete_model):
+        return model._meta.concrete_model._meta if for_concrete_model else model._meta
+
+    def get_for_model(self, model, for_concrete_model=True, project=None):
         if project is None:
             project = get_current_project_name()
-        opts = model._meta
+        opts = self._get_opts(model, for_concrete_model)
         key = (project, opts.app_label, opts.model_name)
         cache = self._get_cache()
         if key in cache:
@@ -44,14 +47,14 @@ class GenericContentTypeManager(models.Manager):
         cache[key] = ct
         return ct
 
-    def get_for_models(self, *models, for_concrete_models=True, project=None):
+    def get_for_models(self, *model_list, for_concrete_models=True, project=None):
         if project is None:
             project = get_current_project_name()
         results = {}
         needed = {}
         cache = self._get_cache()
-        for model in models:
-            opts = model._meta.concrete_model._meta if for_concrete_models else model._meta
+        for model in model_list:
+            opts = self._get_opts(model, for_concrete_models)
             key = (project, opts.app_label, opts.model_name)
             if key in cache:
                 results[model] = cache[key]
@@ -59,23 +62,28 @@ class GenericContentTypeManager(models.Manager):
                 needed.setdefault((opts.app_label, opts.model_name), []).append(model)
 
         if needed:
-            condition = models.Q()
-            for (app_label, model_name) in needed.keys():
-                condition |= models.Q(project=project, app_label=app_label, model=model_name)
+            condition = django_models.Q()
+            for app_label, model_name in needed.keys():
+                condition |= django_models.Q(project=project, app_label=app_label, model=model_name)
             cts = self.filter(condition)
             for ct in cts:
                 key = (ct.app_label, ct.model)
                 for model in needed.pop(key, []):
                     results[model] = ct
                 cache[(ct.project, ct.app_label, ct.model)] = ct
-            for (app_label, model_name), models_list in needed.items():
+            for (app_label, model_name), model_objs in needed.items():
                 ct = self.create(project=project, app_label=app_label, model=model_name)
                 cache[(project, app_label, model_name)] = ct
-                for model in models_list:
+                for model in model_objs:
                     results[model] = ct
         return results
 
-    def get_by_natural_key(self, project, app_label, model):
+    def get_by_natural_key(self, *args):
+        if len(args) == 2:
+            project = get_current_project_name()
+            app_label, model = args
+        else:
+            project, app_label, model = args
         key = (project, app_label, model)
         cache = self._get_cache()
         if key in cache:
@@ -94,12 +102,12 @@ class GenericContentTypeManager(models.Manager):
         return ct
 
 
-class GenericContentType(models.Model):
+class GenericContentType(django_models.Model):
     """Like Django's ``ContentType`` model but scoped by project."""
 
-    project = models.CharField(max_length=100)
-    app_label = models.CharField(max_length=100)
-    model = models.CharField(max_length=100)
+    project = django_models.CharField(max_length=100)
+    app_label = django_models.CharField(max_length=100)
+    model = django_models.CharField(max_length=100)
 
     objects = GenericContentTypeManager()
 
@@ -117,6 +125,11 @@ class GenericContentType(models.Model):
         if not model:
             return self.model
         return str(model._meta.verbose_name)
+
+    @name.setter
+    def name(self, value):
+        """Ignore writes for backward compatibility."""
+        pass
 
     @property
     def app_labeled_name(self):

--- a/federated_foreign_key/models.py
+++ b/federated_foreign_key/models.py
@@ -44,6 +44,37 @@ class GenericContentTypeManager(models.Manager):
         cache[key] = ct
         return ct
 
+    def get_for_models(self, *models, for_concrete_models=True, project=None):
+        if project is None:
+            project = get_current_project_name()
+        results = {}
+        needed = {}
+        cache = self._get_cache()
+        for model in models:
+            opts = model._meta.concrete_model._meta if for_concrete_models else model._meta
+            key = (project, opts.app_label, opts.model_name)
+            if key in cache:
+                results[model] = cache[key]
+            else:
+                needed.setdefault((opts.app_label, opts.model_name), []).append(model)
+
+        if needed:
+            condition = models.Q()
+            for (app_label, model_name) in needed.keys():
+                condition |= models.Q(project=project, app_label=app_label, model=model_name)
+            cts = self.filter(condition)
+            for ct in cts:
+                key = (ct.app_label, ct.model)
+                for model in needed.pop(key, []):
+                    results[model] = ct
+                cache[(ct.project, ct.app_label, ct.model)] = ct
+            for (app_label, model_name), models_list in needed.items():
+                ct = self.create(project=project, app_label=app_label, model=model_name)
+                cache[(project, app_label, model_name)] = ct
+                for model in models_list:
+                    results[model] = ct
+        return results
+
     def get_by_natural_key(self, project, app_label, model):
         key = (project, app_label, model)
         cache = self._get_cache()
@@ -78,7 +109,21 @@ class GenericContentType(models.Model):
         ]
 
     def __str__(self):
-        return f"{self.project}:{self.app_label}.{self.model}"
+        return self.app_labeled_name
+
+    @property
+    def name(self):
+        model = self.model_class()
+        if not model:
+            return self.model
+        return str(model._meta.verbose_name)
+
+    @property
+    def app_labeled_name(self):
+        model = self.model_class()
+        if not model:
+            return self.model
+        return f"{model._meta.app_config.verbose_name} | {model._meta.verbose_name}"
 
     def model_class(self):
         if self.project not in ("shared", get_current_project_name()):
@@ -93,6 +138,12 @@ class GenericContentType(models.Model):
         if model is None:
             raise LookupError("Model not available in this project")
         return model._base_manager.get(**kwargs)
+
+    def get_all_objects_for_this_type(self, **kwargs):
+        model = self.model_class()
+        if model is None:
+            return []
+        return model._base_manager.filter(**kwargs)
 
     def natural_key(self):
         return (self.project, self.app_label, self.model)


### PR DESCRIPTION
## Summary
- switch Django test suite imports to use GenericContentType and FederatedForeignKey
- enable `federated_foreign_key` app in Django test settings
- make runtests.py compatible with Django < 6.1

## Testing
- `ruff check .`
- `flake8`
- `pytest -q`
- `python dj_tests/runtests.py --parallel=1 contenttypes_tests` *(fails: FieldError and other failures)*

------
https://chatgpt.com/codex/tasks/task_e_685a9dbce5788322ba4a41029aee7cda