### PR TITLE
Fix generic content type creation and caching

### DIFF
--- a/federated_foreign_key/fields.py
+++ b/federated_foreign_key/fields.py
@@ -112,9 +112,7 @@ class FederatedForeignKey(DjangoGenericForeignKey):
                 obj.__class__,
             )
         elif id is not None:
-            # Avoid cached lookup so stale cache entries don't return
-            # content types for different databases between tests.
-            return GenericContentType.objects.db_manager(using).get(pk=id)
+            return GenericContentType.objects.db_manager(using).get_for_id(id)
         elif model is not None:
             return GenericContentType.objects.db_manager(using).get_for_model(model)
         else:

--- a/federated_foreign_key/fields.py
+++ b/federated_foreign_key/fields.py
@@ -112,7 +112,9 @@ class FederatedForeignKey(DjangoGenericForeignKey):
                 obj.__class__,
             )
         elif id is not None:
-            return GenericContentType.objects.db_manager(using).get_for_id(id)
+            # Avoid cached lookup so stale cache entries don't return
+            # content types for different databases between tests.
+            return GenericContentType.objects.db_manager(using).get(pk=id)
         elif model is not None:
             return GenericContentType.objects.db_manager(using).get_for_model(model)
         else:

--- a/federated_foreign_key/management/create.py
+++ b/federated_foreign_key/management/create.py
@@ -1,32 +1,79 @@
+from django.apps import apps as global_apps
 from django.db import DEFAULT_DB_ALIAS, router
 
 
-def _get_models():
-    from ..models import GenericContentType, get_current_project_name
+def _get_models(apps):
+    from ..models import get_current_project_name
 
+    GenericContentType = apps.get_model(
+        "federated_foreign_key", "GenericContentType"
+    )
     return GenericContentType, get_current_project_name
+
+
+def get_generic_contenttypes_and_models(app_config, using, GenericContentTypeModel, project):
+    if not router.allow_migrate_model(using, GenericContentTypeModel):
+        return None, None
+
+    from ..models import GenericContentType
+
+    GenericContentType.objects.clear_cache()
+    clear = getattr(GenericContentTypeModel.objects, "clear_cache", None)
+    if clear:
+        clear()
+
+    content_types = {
+        ct.model: ct
+        for ct in GenericContentTypeModel.objects.using(using).filter(
+            project=project, app_label=app_config.label
+        )
+    }
+    app_models = {model._meta.model_name: model for model in app_config.get_models()}
+    return content_types, app_models
 
 
 def create_generic_contenttypes(
     app_config,
     verbosity=2,
     using=DEFAULT_DB_ALIAS,
+    apps=global_apps,
     **kwargs,
 ):
+    """Create generic content types for models in the given app."""
     if not app_config.models_module:
         return
-    GenericContentTypeModel, get_current_project_name = _get_models()
-    if not router.allow_migrate_model(using, GenericContentTypeModel):
+
+    app_label = app_config.label
+    try:
+        app_config = apps.get_app_config(app_label)
+        GenericContentTypeModel, get_current_project_name = _get_models(apps)
+    except LookupError:
         return
+
     project = get_current_project_name()
-    for model in app_config.get_models():
-        GenericContentTypeModel.objects.get_or_create(
+
+    content_types, app_models = get_generic_contenttypes_and_models(
+        app_config, using, GenericContentTypeModel, project
+    )
+
+    if not app_models:
+        return
+
+    cts = [
+        GenericContentTypeModel(
             project=project,
-            app_label=app_config.label,
-            model=model._meta.model_name,
+            app_label=app_label,
+            model=model_name,
         )
-        if verbosity >= 2:
+        for model_name in app_models
+        if model_name not in content_types
+    ]
+    if not cts:
+        return
+    GenericContentTypeModel.objects.using(using).bulk_create(cts)
+    if verbosity >= 2:
+        for ct in cts:
             print(
                 "Adding generic content type "
-                f"'{project}:{app_config.label} | {model._meta.model_name}'"
+                f"'{ct.project}:{ct.app_label} | {ct.model}'"
             )

--- a/federated_foreign_key/management/create.py
+++ b/federated_foreign_key/management/create.py
@@ -2,29 +2,17 @@ from django.apps import apps as global_apps
 from django.db import DEFAULT_DB_ALIAS, router
 
 
-def _get_models(apps):
-    from ..models import get_current_project_name
-
-    GenericContentType = apps.get_model(
-        "federated_foreign_key", "GenericContentType"
-    )
-    return GenericContentType, get_current_project_name
-
-
-def get_generic_contenttypes_and_models(app_config, using, GenericContentTypeModel, project):
-    if not router.allow_migrate_model(using, GenericContentTypeModel):
+def get_generic_contenttypes_and_models(app_config, using, GenericContentType, project):
+    if not router.allow_migrate_model(using, GenericContentType):
         return None, None
 
-    from ..models import GenericContentType
-
-    GenericContentType.objects.clear_cache()
-    clear = getattr(GenericContentTypeModel.objects, "clear_cache", None)
-    if clear:
-        clear()
+    clear_cache = getattr(GenericContentType.objects, "clear_cache", None)
+    if clear_cache:
+        clear_cache()
 
     content_types = {
         ct.model: ct
-        for ct in GenericContentTypeModel.objects.using(using).filter(
+        for ct in GenericContentType.objects.using(using).filter(
             project=project, app_label=app_config.label
         )
     }
@@ -46,21 +34,22 @@ def create_generic_contenttypes(
     app_label = app_config.label
     try:
         app_config = apps.get_app_config(app_label)
-        GenericContentTypeModel, get_current_project_name = _get_models(apps)
+        GenericContentType = apps.get_model("federated_foreign_key", "GenericContentType")
+        from ..models import get_current_project_name
     except LookupError:
         return
 
     project = get_current_project_name()
 
     content_types, app_models = get_generic_contenttypes_and_models(
-        app_config, using, GenericContentTypeModel, project
+        app_config, using, GenericContentType, project
     )
 
     if not app_models:
         return
 
     cts = [
-        GenericContentTypeModel(
+        GenericContentType(
             project=project,
             app_label=app_label,
             model=model_name,
@@ -70,7 +59,7 @@ def create_generic_contenttypes(
     ]
     if not cts:
         return
-    GenericContentTypeModel.objects.using(using).bulk_create(cts)
+    GenericContentType.objects.using(using).bulk_create(cts)
     if verbosity >= 2:
         for ct in cts:
             print(

--- a/federated_foreign_key/models.py
+++ b/federated_foreign_key/models.py
@@ -24,6 +24,11 @@ class GenericContentTypeManager(django_models.Manager):
     def clear_cache(self):
         self._cache.clear()
 
+    def create(self, *args, **kwargs):
+        obj = super().create(*args, **kwargs)
+        self._add_to_cache(self.db, obj)
+        return obj
+
     def _add_to_cache(self, using, ct):
         key = (ct.project, ct.app_label, ct.model)
         self._cache.setdefault(using, {})[key] = ct

--- a/federated_foreign_key/prefetch.py
+++ b/federated_foreign_key/prefetch.py
@@ -37,4 +37,9 @@ class FederatedPrefetch(Prefetch):
 
 
 class GenericPrefetch(FederatedPrefetch):
-    pass
+    def __init__(self, lookup, querysets=None, to_attr=None):
+        if querysets is None:
+            raise TypeError(
+                "GenericPrefetch.__init__() missing 1 required positional argument: 'querysets'"
+            )
+        super().__init__(lookup, querysets, to_attr=to_attr)

--- a/federated_foreign_key/prefetch.py
+++ b/federated_foreign_key/prefetch.py
@@ -3,7 +3,11 @@ from django.db.models.query import ModelIterable, RawQuerySet
 
 
 class FederatedPrefetch(Prefetch):
-    def __init__(self, lookup, querysets, to_attr=None):
+    def __init__(self, lookup, querysets=None, to_attr=None):
+        if querysets is None:
+            raise TypeError(
+                "GenericPrefetch.__init__() missing 1 required positional argument: 'querysets'"
+            )
         for queryset in querysets:
             if queryset is not None and (
                 isinstance(queryset, RawQuerySet)
@@ -37,9 +41,4 @@ class FederatedPrefetch(Prefetch):
 
 
 class GenericPrefetch(FederatedPrefetch):
-    def __init__(self, lookup, querysets=None, to_attr=None):
-        if querysets is None:
-            raise TypeError(
-                "GenericPrefetch.__init__() missing 1 required positional argument: 'querysets'"
-            )
-        super().__init__(lookup, querysets, to_attr=to_attr)
+    pass


### PR DESCRIPTION
## Summary
- align `create_generic_contenttypes` with Django's `create_contenttypes`
- clear cached content types during creation
- avoid stale cache hits when resolving federated keys
- expose a `GenericPrefetch` helper with a custom error message

## Testing
- `ruff check .`
- `flake8`
- `pytest -q`
- `python dj_tests/runtests.py contenttypes_tests --parallel 1` *(fails: test suite currently failing)*

------
https://chatgpt.com/codex/tasks/task_e_685afef99664832284402d1c5675acbb