### PR TITLE
Fix tests to use GenericContentType

### DIFF
--- a/dj_tests/contenttypes_tests/operations_migrations/0002_rename_foo.py
+++ b/dj_tests/contenttypes_tests/operations_migrations/0002_rename_foo.py
@@ -2,7 +2,7 @@ from django.db import migrations
 
 
 def assert_foo_contenttype_not_cached(apps, schema_editor):
-    ContentType = apps.get_model("contenttypes", "ContentType")
+    ContentType = apps.get_model("federated_foreign_key", "GenericContentType")
     try:
         content_type = ContentType.objects.get_by_natural_key(
             "contenttypes_tests", "foo"

--- a/dj_tests/contenttypes_tests/test_models.py
+++ b/dj_tests/contenttypes_tests/test_models.py
@@ -101,8 +101,11 @@ class ContentTypesTests(TestCase):
         )
 
     def test_get_for_models_migrations(self):
-        state = ProjectState.from_apps(apps.get_app_config("contenttypes"))
-        ContentType = state.apps.get_model("contenttypes", "ContentType")
+        state = ProjectState.from_apps(apps.get_app_config("federated_foreign_key"))
+        ContentType = state.apps.get_model(
+            "federated_foreign_key",
+            "GenericContentType",
+        )
         cts = ContentType.objects.get_for_models(ContentType)
         self.assertEqual(
             cts, {ContentType: ContentType.objects.get_for_model(ContentType)}
@@ -110,14 +113,17 @@ class ContentTypesTests(TestCase):
 
     @isolate_apps("contenttypes_tests")
     def test_get_for_models_migrations_create_model(self):
-        state = ProjectState.from_apps(apps.get_app_config("contenttypes"))
+        state = ProjectState.from_apps(apps.get_app_config("federated_foreign_key"))
 
         class Foo(models.Model):
             class Meta:
                 app_label = "contenttypes_tests"
 
         state.add_model(ModelState.from_model(Foo))
-        ContentType = state.apps.get_model("contenttypes", "ContentType")
+        ContentType = state.apps.get_model(
+            "federated_foreign_key",
+            "GenericContentType",
+        )
         cts = ContentType.objects.get_for_models(FooWithUrl, Foo)
         self.assertEqual(
             cts,


### PR DESCRIPTION
## Summary
- update `operations_migrations/0002_rename_foo.py` to use GenericContentType
- update migration tests to use GenericContentType

## Testing
- `ruff check .`
- `flake8`
- `pytest -q`
- `python dj_tests/runtests.py contenttypes_tests --parallel=1`


------
https://chatgpt.com/codex/tasks/task_e_685b6afddf50832286574a6d1cfc7389