### PR TITLE
Add tests for reverse descriptor

### DIFF
--- a/example_project/src/example_project/testapp/models.py
+++ b/example_project/src/example_project/testapp/models.py
@@ -1,5 +1,5 @@
 from django.db import models
-from federated_foreign_key.fields import FederatedForeignKey
+from federated_foreign_key.fields import FederatedForeignKey, FederatedRelation
 from federated_foreign_key.models import GenericContentType
 
 
@@ -7,6 +7,7 @@ class Book(models.Model):
     """Sample model used for tests."""
 
     title = models.CharField(max_length=50)
+    references = FederatedRelation("Reference", related_query_name="book")
 
 
 class Reference(models.Model):

--- a/tests/test_federated_fk.py
+++ b/tests/test_federated_fk.py
@@ -67,3 +67,39 @@ def test_shared_project_local_reference():
     assert ref.content_type.project == "shared"
     assert isinstance(ref.content_object, Book)
     assert ref.content_object.pk == book.pk
+
+
+def test_reverse_manager_add_remove_clear():
+    book = Book.objects.create(title="AddRemove")
+    other = Book.objects.create(title="Other")
+    ct = GenericContentType.objects.get_for_model(Book)
+    ref1 = Reference.objects.create(content_type=ct, object_id=other.pk)
+    ref2 = Reference.objects.create(content_type=ct, object_id=other.pk)
+
+    book.references.add(ref1, ref2)
+    ref1.refresh_from_db()
+    ref2.refresh_from_db()
+    assert set(book.references.all()) == {ref1, ref2}
+    assert ref1.object_id == book.pk
+
+    book.references.remove(ref1)
+    assert list(book.references.all()) == [ref2]
+
+    book.references.clear()
+    assert book.references.count() == 0
+
+
+def test_reverse_manager_create_and_get():
+    book = Book.objects.create(title="Create")
+
+    ref = book.references.create()
+    assert ref.content_object == book
+    assert list(book.references.all()) == [ref]
+
+    same, created = book.references.get_or_create(pk=ref.pk)
+    assert not created
+    assert same == ref
+
+    updated, created = book.references.update_or_create(pk=ref.pk)
+    assert not created
+    assert updated == ref


### PR DESCRIPTION
## Summary
- add FederatedRelation from Book to Reference
- test reverse descriptor manager methods like `add` and `clear`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ffe329b2c832297b065f73e4650c3