### PR TITLE
Add remote object support in GenericContentType

### DIFF
--- a/federated_foreign_key/models.py
+++ b/federated_foreign_key/models.py
@@ -4,6 +4,7 @@ from django.conf import settings
 from django.apps import apps
 from django.db import models as django_models
 
+
 PROJECT_SETTING_NAME = "FEDERATION_PROJECT_NAME"
 
 
@@ -169,14 +170,32 @@ class GenericContentType(django_models.Model):
     def get_object_for_this_type(self, **kwargs):
         model = self.model_class()
         if model is None:
-            raise LookupError("Model not available in this project")
+            from .fields import get_remote_object_class
+            object_id = (
+                kwargs.get("pk")
+                or kwargs.get("id")
+                or kwargs.get("pk__exact")
+                or kwargs.get("id__exact")
+            )
+            if object_id is None:
+                raise LookupError("Model not available in this project")
+            return get_remote_object_class()(self, object_id)
         return model._base_manager.get(**kwargs)
 
     def get_all_objects_for_this_type(self, **kwargs):
         model = self.model_class()
         if model is None:
-            return []
-        return model._base_manager.filter(**kwargs)
+            from .fields import get_remote_object_class
+            ids = (
+                kwargs.get("pk__in")
+                or kwargs.get("id__in")
+                or (kwargs.get("pk") and [kwargs["pk"]])
+                or (kwargs.get("id") and [kwargs["id"]])
+            )
+            if not ids:
+                return []
+            return [get_remote_object_class()(self, obj_id) for obj_id in ids]
+        return list(model._base_manager.filter(**kwargs))
 
     def natural_key(self):
         return (self.project, self.app_label, self.model)

--- a/tests/test_generic_contenttype.py
+++ b/tests/test_generic_contenttype.py
@@ -47,3 +47,35 @@ class GenericContentTypeTests(TestCase):
         ct = GenericContentType.objects.get_for_model(ModelCreatedOnTheFly)
         assert ct.app_label == "tests"
         assert ct.model == "modelcreatedonthefly"
+
+
+def test_get_object_for_this_type_remote():
+    """Remote objects should return a remote proxy."""
+    ct = GenericContentType.objects.create(
+        project="remote_proj",
+        app_label="testapp",
+        model="book",
+    )
+
+    obj = ct.get_object_for_this_type(pk=1)
+
+    from federated_foreign_key.fields import RemoteObject
+
+    assert isinstance(obj, RemoteObject)
+    assert obj.object_id == 1
+    assert obj.content_type == ct
+
+
+def test_get_all_objects_for_this_type_remote():
+    ct = GenericContentType.objects.create(
+        project="remote_proj2",
+        app_label="testapp",
+        model="book",
+    )
+
+    objs = ct.get_all_objects_for_this_type(pk__in=[1, 2])
+
+    from federated_foreign_key.fields import RemoteObject
+
+    assert [o.object_id for o in objs] == [1, 2]
+    assert all(isinstance(o, RemoteObject) for o in objs)


### PR DESCRIPTION
## Summary
- allow `GenericContentType.get_object_for_this_type` and `get_all_objects_for_this_type` to return remote object proxies
- test the new behaviour for remote content types

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6861fccd6d6c8322994bbf62c473d3d0