### PR TITLE
Add help_text to model fields

### DIFF
--- a/dj_tests/contenttypes_tests/models.py
+++ b/dj_tests/contenttypes_tests/models.py
@@ -6,36 +6,60 @@ from federated_foreign_key.fields import FederatedForeignKey
 from federated_foreign_key.models import GenericContentType
 from django.contrib.sites.models import SiteManager
 from django.db import models
+from django.utils.translation import gettext_lazy as _
 
 
 class Site(models.Model):
-    domain = models.CharField(max_length=100)
+    domain = models.CharField(
+        max_length=100,
+        help_text=_("Fully qualified domain name for the site."),
+    )
     objects = SiteManager()
 
 
 class Author(models.Model):
-    name = models.CharField(max_length=100)
+    name = models.CharField(
+        max_length=100,
+        help_text=_("Human readable name of the author."),
+    )
 
     def get_absolute_url(self):
         return "/authors/%s/" % self.id
 
 
 class Article(models.Model):
-    title = models.CharField(max_length=100)
-    slug = models.SlugField()
-    author = models.ForeignKey(Author, models.CASCADE)
-    date_created = models.DateTimeField()
+    title = models.CharField(
+        max_length=100,
+        help_text=_("Title displayed on the article page."),
+    )
+    slug = models.SlugField(
+        help_text=_("URL slug used to build article links."),
+    )
+    author = models.ForeignKey(
+        Author,
+        models.CASCADE,
+        help_text=_("Author that wrote the article."),
+    )
+    date_created = models.DateTimeField(
+        help_text=_("Date and time when the article was created."),
+    )
 
 
 class SchemeIncludedURL(models.Model):
-    url = models.URLField(max_length=100)
+    url = models.URLField(
+        max_length=100,
+        help_text=_("URL including the scheme part."),
+    )
 
     def get_absolute_url(self):
         return self.url
 
 
 class ConcreteModel(models.Model):
-    name = models.CharField(max_length=10)
+    name = models.CharField(
+        max_length=10,
+        help_text=_("Simple name used in content type tests."),
+    )
 
 
 class ProxyModel(ConcreteModel):
@@ -49,7 +73,11 @@ class FooWithoutUrl(models.Model):
     ContentTypesTests.test_shortcut_view_without_get_absolute_url()
     """
 
-    name = models.CharField(max_length=30, unique=True)
+    name = models.CharField(
+        max_length=30,
+        unique=True,
+        help_text=_("Unique text used as a lookup key."),
+    )
 
 
 class FooWithUrl(FooWithoutUrl):
@@ -72,14 +100,29 @@ class FooWithBrokenAbsoluteUrl(FooWithoutUrl):
 
 
 class Question(models.Model):
-    text = models.CharField(max_length=200)
-    answer_set = GenericRelation("Answer")
+    text = models.CharField(
+        max_length=200,
+        help_text=_("Question text presented to users."),
+    )
+    answer_set = GenericRelation(
+        "Answer",
+        help_text=_("Answers associated with this question."),
+    )
 
 
 class Answer(models.Model):
-    text = models.CharField(max_length=200)
-    content_type = models.ForeignKey(GenericContentType, models.CASCADE)
-    object_id = models.PositiveIntegerField()
+    text = models.CharField(
+        max_length=200,
+        help_text=_("Answer text for the question."),
+    )
+    content_type = models.ForeignKey(
+        GenericContentType,
+        models.CASCADE,
+        help_text=_("Content type of the related object."),
+    )
+    object_id = models.PositiveIntegerField(
+        help_text=_("ID of the related object."),
+    )
     question = FederatedForeignKey()
 
     class Meta:
@@ -89,35 +132,72 @@ class Answer(models.Model):
 class Post(models.Model):
     """An ordered tag on an item."""
 
-    title = models.CharField(max_length=200)
-    content_type = models.ForeignKey(GenericContentType, models.CASCADE, null=True)
-    object_id = models.PositiveIntegerField(null=True)
+    title = models.CharField(
+        max_length=200,
+        help_text=_("Title for the post item."),
+    )
+    content_type = models.ForeignKey(
+        GenericContentType,
+        models.CASCADE,
+        null=True,
+        help_text=_("Type of the related object if any."),
+    )
+    object_id = models.PositiveIntegerField(
+        null=True,
+        help_text=_("ID of the related object if any."),
+    )
     parent = FederatedForeignKey()
-    children = GenericRelation("Post")
+    children = GenericRelation(
+        "Post",
+        help_text=_("Child posts linked to this post."),
+    )
 
     class Meta:
         order_with_respect_to = "parent"
 
 
 class ModelWithNullFKToSite(models.Model):
-    title = models.CharField(max_length=200)
-    site = models.ForeignKey(Site, null=True, on_delete=models.CASCADE)
-    post = models.ForeignKey(Post, null=True, on_delete=models.CASCADE)
+    title = models.CharField(
+        max_length=200,
+        help_text=_("Descriptive title for the object."),
+    )
+    site = models.ForeignKey(
+        Site,
+        null=True,
+        on_delete=models.CASCADE,
+        help_text=_("Optional site owning this entry."),
+    )
+    post = models.ForeignKey(
+        Post,
+        null=True,
+        on_delete=models.CASCADE,
+        help_text=_("Optional post referenced by this entry."),
+    )
 
     def get_absolute_url(self):
         return "/title/%s/" % quote(self.title)
 
 
 class ModelWithM2MToSite(models.Model):
-    title = models.CharField(max_length=200)
-    sites = models.ManyToManyField(Site)
+    title = models.CharField(
+        max_length=200,
+        help_text=_("Title for the item."),
+    )
+    sites = models.ManyToManyField(
+        Site,
+        help_text=_("Sites this item appears on."),
+    )
 
     def get_absolute_url(self):
         return "/title/%s/" % quote(self.title)
 
 
 class UUIDModel(models.Model):
-    id = models.UUIDField(primary_key=True, default=uuid.uuid4)
+    id = models.UUIDField(
+        primary_key=True,
+        default=uuid.uuid4,
+        help_text=_("Unique identifier stored as UUID."),
+    )
 
     def get_absolute_url(self):
         return "/uuid/%s/" % self.pk

--- a/dj_tests/contenttypes_tests/test_checks.py
+++ b/dj_tests/contenttypes_tests/test_checks.py
@@ -8,6 +8,7 @@ from django.core import checks
 from django.db import models
 from django.test import SimpleTestCase, override_settings
 from django.test.utils import isolate_apps
+from django.utils.translation import gettext_lazy as _
 
 
 @isolate_apps("contenttypes_tests", attr_name="apps")
@@ -17,7 +18,9 @@ class GenericForeignKeyTests(SimpleTestCase):
     def test_missing_content_type_field(self):
         class TaggedItem(models.Model):
             # no content_type field
-            object_id = models.PositiveIntegerField()
+            object_id = models.PositiveIntegerField(
+                help_text=_("Primary key of the related object."),
+            )
             content_object = GenericForeignKey()
 
         expected = [
@@ -32,8 +35,12 @@ class GenericForeignKeyTests(SimpleTestCase):
 
     def test_invalid_content_type_field(self):
         class Model(models.Model):
-            content_type = models.IntegerField()  # should be ForeignKey
-            object_id = models.PositiveIntegerField()
+            content_type = models.IntegerField(
+                help_text=_("Should be a ForeignKey to GenericContentType."),
+            )  # should be ForeignKey
+            object_id = models.PositiveIntegerField(
+                help_text=_("Primary key of the related object."),
+            )
             content_object = GenericForeignKey("content_type", "object_id")
 
         self.assertEqual(
@@ -54,9 +61,13 @@ class GenericForeignKeyTests(SimpleTestCase):
     def test_content_type_field_pointing_to_wrong_model(self):
         class Model(models.Model):
             content_type = models.ForeignKey(
-                "self", models.CASCADE
+                "self",
+                models.CASCADE,
+                help_text=_("Should reference GenericContentType."),
             )  # should point to ContentType
-            object_id = models.PositiveIntegerField()
+            object_id = models.PositiveIntegerField(
+                help_text=_("Primary key of the related object."),
+            )
             content_object = GenericForeignKey("content_type", "object_id")
 
         self.assertEqual(
@@ -77,7 +88,11 @@ class GenericForeignKeyTests(SimpleTestCase):
 
     def test_missing_object_id_field(self):
         class TaggedItem(models.Model):
-            content_type = models.ForeignKey(ContentType, models.CASCADE)
+            content_type = models.ForeignKey(
+                ContentType,
+                models.CASCADE,
+                help_text=_("Content type of the related object."),
+            )
             # missing object_id field
             content_object = GenericForeignKey()
 
@@ -95,8 +110,14 @@ class GenericForeignKeyTests(SimpleTestCase):
 
     def test_field_name_ending_with_underscore(self):
         class Model(models.Model):
-            content_type = models.ForeignKey(ContentType, models.CASCADE)
-            object_id = models.PositiveIntegerField()
+            content_type = models.ForeignKey(
+                ContentType,
+                models.CASCADE,
+                help_text=_("Content type of the related object."),
+            )
+            object_id = models.PositiveIntegerField(
+                help_text=_("Primary key of the related object."),
+            )
             content_object_ = GenericForeignKey("content_type", "object_id")
 
         self.assertEqual(
@@ -130,19 +151,34 @@ class GenericForeignKeyTests(SimpleTestCase):
 class GenericRelationTests(SimpleTestCase):
     def test_valid_generic_relationship(self):
         class TaggedItem(models.Model):
-            content_type = models.ForeignKey(ContentType, models.CASCADE)
-            object_id = models.PositiveIntegerField()
+            content_type = models.ForeignKey(
+                ContentType,
+                models.CASCADE,
+                help_text=_("Content type of the tagged object."),
+            )
+            object_id = models.PositiveIntegerField(
+                help_text=_("Primary key of the tagged object."),
+            )
             content_object = GenericForeignKey()
 
         class Bookmark(models.Model):
-            tags = GenericRelation("TaggedItem")
+            tags = GenericRelation(
+                "TaggedItem",
+                help_text=_("Generic relation to TaggedItem."),
+            )
 
         self.assertEqual(Bookmark.tags.field.check(), [])
 
     def test_valid_generic_relationship_with_explicit_fields(self):
         class TaggedItem(models.Model):
-            custom_content_type = models.ForeignKey(ContentType, models.CASCADE)
-            custom_object_id = models.PositiveIntegerField()
+            custom_content_type = models.ForeignKey(
+                ContentType,
+                models.CASCADE,
+                help_text=_("Custom content type field."),
+            )
+            custom_object_id = models.PositiveIntegerField(
+                help_text=_("Custom object identifier."),
+            )
             content_object = GenericForeignKey(
                 "custom_content_type", "custom_object_id"
             )
@@ -152,13 +188,17 @@ class GenericRelationTests(SimpleTestCase):
                 "TaggedItem",
                 content_type_field="custom_content_type",
                 object_id_field="custom_object_id",
+                help_text=_("Generic relation using explicit fields."),
             )
 
         self.assertEqual(Bookmark.tags.field.check(), [])
 
     def test_pointing_to_missing_model(self):
         class Model(models.Model):
-            rel = GenericRelation("MissingModel")
+            rel = GenericRelation(
+                "MissingModel",
+                help_text=_("Relation pointing to a missing model."),
+            )
 
         self.assertEqual(
             Model.rel.field.check(),
@@ -174,20 +214,38 @@ class GenericRelationTests(SimpleTestCase):
 
     def test_valid_self_referential_generic_relationship(self):
         class Model(models.Model):
-            rel = GenericRelation("Model")
-            content_type = models.ForeignKey(ContentType, models.CASCADE)
-            object_id = models.PositiveIntegerField()
+            rel = GenericRelation(
+                "Model",
+                help_text=_("Self-referential generic relation."),
+            )
+            content_type = models.ForeignKey(
+                ContentType,
+                models.CASCADE,
+                help_text=_("Content type of the related object."),
+            )
+            object_id = models.PositiveIntegerField(
+                help_text=_("Primary key of the related object."),
+            )
             content_object = GenericForeignKey("content_type", "object_id")
 
         self.assertEqual(Model.rel.field.check(), [])
 
     def test_missing_generic_foreign_key(self):
         class TaggedItem(models.Model):
-            content_type = models.ForeignKey(ContentType, models.CASCADE)
-            object_id = models.PositiveIntegerField()
+            content_type = models.ForeignKey(
+                ContentType,
+                models.CASCADE,
+                help_text=_("Content type of the related object."),
+            )
+            object_id = models.PositiveIntegerField(
+                help_text=_("Primary key of the related object."),
+            )
 
         class Bookmark(models.Model):
-            tags = GenericRelation("TaggedItem")
+            tags = GenericRelation(
+                "TaggedItem",
+                help_text=_("Relation to TaggedItem without a GenericForeignKey."),
+            )
 
         self.assertEqual(
             Bookmark.tags.field.check(),
@@ -208,15 +266,24 @@ class GenericRelationTests(SimpleTestCase):
             pass
 
         class SwappedModel(models.Model):
-            content_type = models.ForeignKey(ContentType, models.CASCADE)
-            object_id = models.PositiveIntegerField()
+            content_type = models.ForeignKey(
+                ContentType,
+                models.CASCADE,
+                help_text=_("Content type of the related object."),
+            )
+            object_id = models.PositiveIntegerField(
+                help_text=_("Primary key of the related object."),
+            )
             content_object = GenericForeignKey()
 
             class Meta:
                 swappable = "TEST_SWAPPED_MODEL"
 
         class Model(models.Model):
-            rel = GenericRelation("SwappedModel")
+            rel = GenericRelation(
+                "SwappedModel",
+                help_text=_("Relation to a swapped model."),
+            )
 
         self.assertEqual(
             Model.rel.field.check(),
@@ -236,12 +303,21 @@ class GenericRelationTests(SimpleTestCase):
 
     def test_field_name_ending_with_underscore(self):
         class TaggedItem(models.Model):
-            content_type = models.ForeignKey(ContentType, models.CASCADE)
-            object_id = models.PositiveIntegerField()
+            content_type = models.ForeignKey(
+                ContentType,
+                models.CASCADE,
+                help_text=_("Content type of the related object."),
+            )
+            object_id = models.PositiveIntegerField(
+                help_text=_("Primary key of the related object."),
+            )
             content_object = GenericForeignKey()
 
         class InvalidBookmark(models.Model):
-            tags_ = GenericRelation("TaggedItem")
+            tags_ = GenericRelation(
+                "TaggedItem",
+                help_text=_("Relation with invalid field name."),
+            )
 
         self.assertEqual(
             InvalidBookmark.tags_.field.check(),

--- a/dj_tests/contenttypes_tests/test_models.py
+++ b/dj_tests/contenttypes_tests/test_models.py
@@ -8,6 +8,7 @@ from django.db import models
 from django.db.migrations.state import ModelState, ProjectState
 from django.test import TestCase, override_settings
 from django.test.utils import isolate_apps
+from django.utils.translation import gettext_lazy as _
 
 from .models import Author, ConcreteModel, FooWithUrl, ProxyModel
 
@@ -155,7 +156,9 @@ class ContentTypesTests(TestCase):
         """
 
         class ModelCreatedOnTheFly(models.Model):
-            name = models.CharField()
+            name = models.CharField(
+                help_text=_("Name for the dynamically created model."),
+            )
 
         ct = ContentType.objects.get_for_model(ModelCreatedOnTheFly)
         self.assertEqual(ct.app_label, "contenttypes_tests")

--- a/dj_tests/order_with_respect_to/models.py
+++ b/dj_tests/order_with_respect_to/models.py
@@ -3,15 +3,26 @@ Tests for the order_with_respect_to Meta attribute.
 """
 
 from django.db import models
+from django.utils.translation import gettext_lazy as _
 
 
 class Question(models.Model):
-    text = models.CharField(max_length=200)
+    text = models.CharField(
+        max_length=200,
+        help_text=_("The actual question being asked."),
+    )
 
 
 class Answer(models.Model):
-    text = models.CharField(max_length=200)
-    question = models.ForeignKey(Question, models.CASCADE)
+    text = models.CharField(
+        max_length=200,
+        help_text=_("Answer text shown for the question."),
+    )
+    question = models.ForeignKey(
+        Question,
+        models.CASCADE,
+        help_text=_("Question this answer belongs to."),
+    )
 
     class Meta:
         order_with_respect_to = "question"
@@ -21,9 +32,16 @@ class Answer(models.Model):
 
 
 class Post(models.Model):
-    title = models.CharField(max_length=200)
+    title = models.CharField(
+        max_length=200,
+        help_text=_("Displayed title for the post."),
+    )
     parent = models.ForeignKey(
-        "self", models.SET_NULL, related_name="children", null=True
+        "self",
+        models.SET_NULL,
+        related_name="children",
+        null=True,
+        help_text=_("Parent post in the hierarchy."),
     )
 
     class Meta:
@@ -39,11 +57,20 @@ class Entity(models.Model):
 
 
 class Dimension(models.Model):
-    entity = models.OneToOneField("Entity", primary_key=True, on_delete=models.CASCADE)
+    entity = models.OneToOneField(
+        "Entity",
+        primary_key=True,
+        on_delete=models.CASCADE,
+        help_text=_("Entity that this dimension extends."),
+    )
 
 
 class Component(models.Model):
-    dimension = models.ForeignKey("Dimension", on_delete=models.CASCADE)
+    dimension = models.ForeignKey(
+        "Dimension",
+        on_delete=models.CASCADE,
+        help_text=_("Dimension that this component refers to."),
+    )
 
     class Meta:
         order_with_respect_to = "dimension"

--- a/dj_tests/order_with_respect_to/tests.py
+++ b/dj_tests/order_with_respect_to/tests.py
@@ -3,6 +3,7 @@ from operator import attrgetter
 from django.db import models
 from django.test import SimpleTestCase, TestCase
 from django.test.utils import isolate_apps
+from django.utils.translation import gettext_lazy as _
 
 from .base_tests import BaseOrderWithRespectToTests
 from .models import Answer, Dimension, Entity, Post, Question
@@ -22,7 +23,11 @@ class OrderWithRespectToTests(SimpleTestCase):
                 app_label = "order_with_respect_to"
 
         class Foo(models.Model):
-            bar = models.ForeignKey(Bar, models.CASCADE)
+            bar = models.ForeignKey(
+                Bar,
+                models.CASCADE,
+                help_text=_("Related Bar instance used for ordering."),
+            )
             order = models.OrderWrt()
 
             class Meta:

--- a/example_project/src/example_project/testapp/models.py
+++ b/example_project/src/example_project/testapp/models.py
@@ -1,4 +1,5 @@
 from django.db import models
+from django.utils.translation import gettext_lazy as _
 from federated_foreign_key.fields import FederatedForeignKey, FederatedRelation
 from federated_foreign_key.models import GenericContentType
 
@@ -6,8 +7,15 @@ from federated_foreign_key.models import GenericContentType
 class Book(models.Model):
     """Sample model used for tests."""
 
-    title = models.CharField(max_length=50)
-    references = FederatedRelation("Reference", related_query_name="book")
+    title = models.CharField(
+        max_length=50,
+        help_text=_("Title of the book used in demo data."),
+    )
+    references = FederatedRelation(
+        "Reference",
+        related_query_name="book",
+        help_text=_("References to objects in any project."),
+    )
 
 
 class Reference(models.Model):
@@ -16,6 +24,9 @@ class Reference(models.Model):
     content_type = models.ForeignKey(
         GenericContentType,
         on_delete=models.CASCADE,
+        help_text=_("Type of the referenced object."),
     )
-    object_id = models.PositiveIntegerField()
+    object_id = models.PositiveIntegerField(
+        help_text=_("Identifier of the referenced object."),
+    )
     content_object = FederatedForeignKey("content_type", "object_id")

--- a/federated_foreign_key/models.py
+++ b/federated_foreign_key/models.py
@@ -161,7 +161,10 @@ class GenericContentType(django_models.Model):
     )
     model = django_models.CharField(
         max_length=100,
-        help_text=_("Name of the model referenced."),
+        help_text=_(
+            "Model name in ``Model._meta.model_name`` format, e.g."
+            " 'JobTemplate' becomes 'jobtemplate'."
+        ),
     )
 
     objects = GenericContentTypeManager()

--- a/federated_foreign_key/models.py
+++ b/federated_foreign_key/models.py
@@ -157,13 +157,15 @@ class GenericContentType(django_models.Model):
     )
     app_label = django_models.CharField(
         max_length=100,
-        help_text=_("Application label that defines the model."),
+        help_text=_(
+            "Django app label where the referenced model is defined."
+        ),
     )
     model = django_models.CharField(
         max_length=100,
         help_text=_(
-            "Model name in ``Model._meta.model_name`` format, e.g."
-            " 'JobTemplate' becomes 'jobtemplate'."
+            "Name of the model in Django's ``Model._meta.model_name`` format. "
+            "For example ``JobTemplate`` becomes ``jobtemplate``."
         ),
     )
 

--- a/federated_foreign_key/models.py
+++ b/federated_foreign_key/models.py
@@ -4,6 +4,7 @@ from typing import Any, Dict, Optional, Sequence, Tuple, Type
 from django.conf import settings
 from django.apps import apps
 from django.db import models as django_models
+from django.utils.translation import gettext_lazy as _
 from django.db.models.options import Options
 
 
@@ -149,9 +150,19 @@ class GenericContentTypeManager(django_models.Manager["GenericContentType"]):
 class GenericContentType(django_models.Model):
     """Like Django's ``ContentType`` model but scoped by project."""
 
-    project = django_models.CharField(max_length=100, default=get_current_project_name)
-    app_label = django_models.CharField(max_length=100)
-    model = django_models.CharField(max_length=100)
+    project = django_models.CharField(
+        max_length=100,
+        default=get_current_project_name,
+        help_text=_("Project namespace used for federated lookups."),
+    )
+    app_label = django_models.CharField(
+        max_length=100,
+        help_text=_("Application label that defines the model."),
+    )
+    model = django_models.CharField(
+        max_length=100,
+        help_text=_("Name of the model referenced."),
+    )
 
     objects = GenericContentTypeManager()
 

--- a/remote_project/src/remote_project/remoteapp/models.py
+++ b/remote_project/src/remote_project/remoteapp/models.py
@@ -1,7 +1,11 @@
 from django.db import models
+from django.utils.translation import gettext_lazy as _
 
 
 class Book(models.Model):
     """Book model for remote project."""
 
-    title = models.CharField(max_length=50)
+    title = models.CharField(
+        max_length=50,
+        help_text=_("Title stored in the remote project's database."),
+    )

--- a/tests/test_generic_contenttype.py
+++ b/tests/test_generic_contenttype.py
@@ -2,6 +2,7 @@ import pytest
 from django.db import models
 from django.test import TestCase
 from django.test.utils import isolate_apps
+from django.utils.translation import gettext_lazy as _
 
 from federated_foreign_key.models import GenericContentType
 from example_project.testapp.models import Book
@@ -39,7 +40,10 @@ class GenericContentTypeTests(TestCase):
     @isolate_apps("tests")
     def test_get_for_model_create_contenttype(self):
         class ModelCreatedOnTheFly(models.Model):
-            name = models.CharField(max_length=10)
+            name = models.CharField(
+                max_length=10,
+                help_text=_("Label for the temporary model instance."),
+            )
 
             class Meta:
                 app_label = "tests"


### PR DESCRIPTION
## Summary
- provide translations for help text across example apps and tests
- document GenericContentType model fields
- improve test models with helpful descriptions
- add help text for order_with_respect_to app

## Testing
- `ruff check .`
- `flake8`
- `pytest -q`
- `python dj_tests/runtests.py contenttypes_tests --parallel=1`


------
https://chatgpt.com/codex/tasks/task_e_686282cb894483228589f492cc2f862a