### PR TITLE
Add test for content type creation with existing remote entry

### DIFF
--- a/tests/test_generic_contenttype.py
+++ b/tests/test_generic_contenttype.py
@@ -15,6 +15,28 @@ def test_post_migrate_creates_contenttype():
     assert ct.project == "project_a"
 
 
+def test_post_migrate_creates_contenttype_with_existing_remote():
+    """A content type is created even if another project already defined it."""
+    # Remove the content type created during migrations.
+    GenericContentType.objects.filter(
+        project="project_a", app_label="testapp", model="book"
+    ).delete()
+
+    # Simulate a content type created by a different project.
+    GenericContentType.objects.create(
+        project="project_b", app_label="testapp", model="book"
+    )
+
+    from django.apps import apps
+    from federated_foreign_key import management as contenttypes_management
+
+    app_config = apps.get_app_config("testapp")
+    contenttypes_management.create_generic_contenttypes(app_config, verbosity=0)
+
+    ct = GenericContentType.objects.get(project="project_a", app_label="testapp", model="book")
+    assert ct.project == "project_a"
+
+
 class GenericContentTypeTests(TestCase):
     def setUp(self):
         GenericContentType.objects.clear_cache()


### PR DESCRIPTION
## Summary
- ensure GenericContentType creation works when an entry for the same model exists in a different project

## Testing
- `ruff check tests/test_generic_contenttype.py`
- `flake8 tests/test_generic_contenttype.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6862ad640d288322825296f287506a06