### PR TITLE
Bump version to 0.1.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "django-federated-foreign-key"
-version = "0.1.0"
+version = "0.1.1"
 description = "GenericForeignKey that can reference objects across projects"
 readme = "README.md"
 requires-python = ">=3.8"


### PR DESCRIPTION
## Summary
- bump version to `0.1.1` in `pyproject.toml`

## Testing
- `ruff check .`
- `flake8`
- `mypy --ignore-missing-imports federated_foreign_key`
- `pytest -q`
- `python dj_tests/runtests.py contenttypes_tests --parallel=1`


------
https://chatgpt.com/codex/tasks/task_e_6862d61ab9988322b8168a3c547dec13