### PR TITLE
Enable setuptools-scm based versioning

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "django-federated-foreign-key"
-version = "0.1.0"
+dynamic = ["version"]
 description = "GenericForeignKey that can reference objects across projects"
 readme = "README.md"
 requires-python = ">=3.8"
@@ -13,9 +13,14 @@ where = ["."]
 include = ["federated_foreign_key*"]
 
 [build-system]
-requires = ["setuptools>=61"]
+requires = [
+    "setuptools>=61",
+    "setuptools-scm>=8",
+]
 build-backend = "setuptools.build_meta"
 
 [tool.ruff]
 target-version = "py313"
+
+[tool.setuptools_scm]
 


### PR DESCRIPTION
## Summary
- switch to setuptools-scm so release versions come from Git tags

## Testing
- `pip install -r requirements-dev.txt`
- `pip install -e .`
- `PYTHONPATH=example_project/src pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6862d71a64988322b95b7cba9f8f2772