### PR TITLE
Add remote stand-ins for model_class()

### DIFF
--- a/federated_foreign_key/fields.py
+++ b/federated_foreign_key/fields.py
@@ -37,6 +37,23 @@ def get_remote_object_class():
     return import_string(path)
 
 
+_REMOTE_STANDIN_CACHE = {}
+
+
+def get_remote_standin_class(content_type: GenericContentType):
+    """Return a RemoteObject subclass unique to ``content_type``."""
+    key = (content_type.project, content_type.app_label, content_type.model)
+    standin = _REMOTE_STANDIN_CACHE.get(key)
+    if standin is None:
+        base = get_remote_object_class()
+        name = (
+            f"Remote[{content_type.project}:{content_type.app_label}.{content_type.model}]"
+        )
+        standin = type(name, (base,), {})
+        _REMOTE_STANDIN_CACHE[key] = standin
+    return standin
+
+
 class RemoteObject:
     """Placeholder for objects that live in another project."""
 
@@ -141,7 +158,7 @@ class FederatedForeignKey(DjangoGenericForeignKey):
                 except (ObjectDoesNotExist, LookupError):
                     rel_obj = None
             else:
-                rel_obj = get_remote_object_class()(ct, pk_val)
+                rel_obj = ct.get_object_for_this_type(pk=pk_val)
         self.set_cached_value(instance, rel_obj)
         return rel_obj
 

--- a/federated_foreign_key/fields.py
+++ b/federated_foreign_key/fields.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import functools
 import itertools
 
@@ -37,7 +39,7 @@ def get_remote_object_class():
     return import_string(path)
 
 
-_REMOTE_STANDIN_CACHE = {}
+_REMOTE_STANDIN_CACHE: dict[tuple[str, str, str], type[RemoteObject]] = {}
 
 
 def get_remote_standin_class(content_type: GenericContentType):

--- a/federated_foreign_key/fields.py
+++ b/federated_foreign_key/fields.py
@@ -49,7 +49,17 @@ def get_remote_standin_class(content_type: GenericContentType):
         name = (
             f"Remote[{content_type.project}:{content_type.app_label}.{content_type.model}]"
         )
-        standin = type(name, (base,), {})
+
+        class StandinMeta:
+            def __init__(self, ct: GenericContentType):
+                self.model_name = ct.model
+                self.app_label = ct.app_label
+
+        standin = type(
+            name,
+            (base,),
+            {"_meta": StandinMeta(content_type)},
+        )
         _REMOTE_STANDIN_CACHE[key] = standin
     return standin
 

--- a/federated_foreign_key/models.py
+++ b/federated_foreign_key/models.py
@@ -182,14 +182,23 @@ class GenericContentType(django_models.Model):
     @property
     def name(self) -> str:
         model = self.model_class()
-        if not model or not hasattr(model, "_meta"):
+        if (
+            not model
+            or not hasattr(model, "_meta")
+            or not hasattr(model._meta, "verbose_name")
+        ):
             return self.model
         return str(model._meta.verbose_name)
 
     @property
     def app_labeled_name(self) -> str:
         model = self.model_class()
-        if not model or not hasattr(model, "_meta"):
+        if (
+            not model
+            or not hasattr(model, "_meta")
+            or not hasattr(model._meta, "app_config")
+            or not hasattr(model._meta, "verbose_name")
+        ):
             return self.model
         return f"{model._meta.app_config.verbose_name} | {model._meta.verbose_name}"
 

--- a/federated_foreign_key/models.py
+++ b/federated_foreign_key/models.py
@@ -182,21 +182,22 @@ class GenericContentType(django_models.Model):
     @property
     def name(self) -> str:
         model = self.model_class()
-        if not model:
+        if not model or not hasattr(model, "_meta"):
             return self.model
         return str(model._meta.verbose_name)
 
     @property
     def app_labeled_name(self) -> str:
         model = self.model_class()
-        if not model:
+        if not model or not hasattr(model, "_meta"):
             return self.model
         return f"{model._meta.app_config.verbose_name} | {model._meta.verbose_name}"
 
     def model_class(self) -> Optional[Type[django_models.Model]]:
-        """Return the model class if available for the current project."""
+        """Return the model class or a remote stand-in."""
         if self.project not in ("shared", get_current_project_name()):
-            return None
+            from .fields import get_remote_standin_class
+            return get_remote_standin_class(self)
         try:
             return apps.get_model(self.app_label, self.model)
         except LookupError:
@@ -215,7 +216,20 @@ class GenericContentType(django_models.Model):
             )
             if object_id is None:
                 raise LookupError("Model not available in this project")
-            return get_remote_object_class()(self, object_id)
+            remote_base = get_remote_object_class()
+            return remote_base(self, object_id)
+        from .fields import get_remote_object_class
+        remote_base = get_remote_object_class()
+        if issubclass(model, remote_base):
+            object_id = (
+                kwargs.get("pk")
+                or kwargs.get("id")
+                or kwargs.get("pk__exact")
+                or kwargs.get("id__exact")
+            )
+            if object_id is None:
+                raise LookupError("Model not available in this project")
+            return model(self, object_id)
         return model._base_manager.get(**kwargs)
 
     def get_all_objects_for_this_type(
@@ -233,7 +247,20 @@ class GenericContentType(django_models.Model):
             )
             if not ids:
                 return []
-            return [get_remote_object_class()(self, obj_id) for obj_id in ids]
+            remote_base = get_remote_object_class()
+            return [remote_base(self, obj_id) for obj_id in ids]
+        from .fields import get_remote_object_class
+        remote_base = get_remote_object_class()
+        if issubclass(model, remote_base):
+            ids = (
+                kwargs.get("pk__in")
+                or kwargs.get("id__in")
+                or (kwargs.get("pk") and [kwargs["pk"]])
+                or (kwargs.get("id") and [kwargs["id"]])
+            )
+            if not ids:
+                return []
+            return [model(self, obj_id) for obj_id in ids]
         return list(model._base_manager.filter(**kwargs))
 
     def natural_key(self) -> Tuple[str, str, str]:

--- a/federated_foreign_key/models.py
+++ b/federated_foreign_key/models.py
@@ -216,17 +216,7 @@ class GenericContentType(django_models.Model):
         """Return the object referenced by this content type."""
         model = self.model_class()
         if model is None:
-            from .fields import get_remote_object_class
-            object_id = (
-                kwargs.get("pk")
-                or kwargs.get("id")
-                or kwargs.get("pk__exact")
-                or kwargs.get("id__exact")
-            )
-            if object_id is None:
-                raise LookupError("Model not available in this project")
-            remote_base = get_remote_object_class()
-            return remote_base(self, object_id)
+            raise LookupError("Model not available in this project")
         from .fields import get_remote_object_class
         remote_base = get_remote_object_class()
         if issubclass(model, remote_base):
@@ -247,17 +237,7 @@ class GenericContentType(django_models.Model):
         """Return all objects referenced by this content type."""
         model = self.model_class()
         if model is None:
-            from .fields import get_remote_object_class
-            ids = (
-                kwargs.get("pk__in")
-                or kwargs.get("id__in")
-                or (kwargs.get("pk") and [kwargs["pk"]])
-                or (kwargs.get("id") and [kwargs["id"]])
-            )
-            if not ids:
-                return []
-            remote_base = get_remote_object_class()
-            return [remote_base(self, obj_id) for obj_id in ids]
+            raise LookupError("Model not available in this project")
         from .fields import get_remote_object_class
         remote_base = get_remote_object_class()
         if issubclass(model, remote_base):

--- a/tests/test_federated_fk.py
+++ b/tests/test_federated_fk.py
@@ -37,6 +37,7 @@ def test_remote_reference():
     from federated_foreign_key.fields import RemoteObject
 
     assert isinstance(obj, RemoteObject)
+    assert isinstance(obj, ct.model_class())
     assert obj.object_id == 1
     assert obj.content_type.project == remote_project
 
@@ -54,6 +55,7 @@ def test_custom_remote_object(settings):
     obj = ref.content_object
 
     assert isinstance(obj, ExtraRemoteObject)
+    assert isinstance(obj, ct.model_class())
     assert obj.extra() == remote_project
 
 

--- a/tests/test_generic_contenttype.py
+++ b/tests/test_generic_contenttype.py
@@ -105,3 +105,20 @@ def test_get_all_objects_for_this_type_remote():
 
     assert [o.object_id for o in objs] == [1, 2]
     assert all(isinstance(o, RemoteObject) for o in objs)
+
+
+def test_model_class_remote_returns_standin():
+    ct = GenericContentType.objects.create(
+        project="remote_proj3",
+        app_label="testapp",
+        model="book",
+    )
+
+    cls1 = ct.model_class()
+    cls2 = ct.model_class()
+    from federated_foreign_key.fields import RemoteObject
+
+    assert issubclass(cls1, RemoteObject)
+    assert cls1 is cls2
+    obj = ct.get_object_for_this_type(pk=5)
+    assert isinstance(obj, cls1)

--- a/tests/test_generic_contenttype.py
+++ b/tests/test_generic_contenttype.py
@@ -119,6 +119,8 @@ def test_model_class_remote_returns_standin():
     from federated_foreign_key.fields import RemoteObject
 
     assert issubclass(cls1, RemoteObject)
+    assert cls1._meta.model_name == "book"
+    assert cls1._meta.app_label == "testapp"
     assert cls1 is cls2
     obj = ct.get_object_for_this_type(pk=5)
     assert isinstance(obj, cls1)


### PR DESCRIPTION
## Summary
- provide stand-in classes for remote content types
- use stand-ins in GenericForeignKey lookup
- handle stand-ins when displaying GenericContentType
- test remote stand-ins

## Testing
- `ruff check .`
- `flake8`
- `pytest -q`
- `python dj_tests/runtests.py contenttypes_tests --parallel=1`


------
https://chatgpt.com/codex/tasks/task_e_686404eb957483228131ba546dd8d559