### PR TITLE
Update README remote object usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,23 @@ class Reference(models.Model):
     content_object = FederatedForeignKey("content_type", "object_id")
 ```
 
+#### Referencing a remote object
+
+If the referenced item does not exist in the local database, `content_object`
+becomes a `RemoteObject` placeholder. `GenericContentType.model_class()`
+returns a stand‑in class that can be used for `isinstance` checks.
+
+```python
+remote_ct = GenericContentType.objects.create(
+    project="project_b",
+    app_label="testapp",
+    model="book",
+)
+cls = remote_ct.model_class()
+ref = Reference.objects.create(content_type=remote_ct, object_id=42)
+assert isinstance(ref.content_object, cls)
+```
+
 ### Development
 
 Install development requirements and run linting and tests:


### PR DESCRIPTION
## Summary
- document how missing remote content objects behave in example

## Testing
- `ruff check .`
- `flake8`
- `pytest -q`
- `python dj_tests/runtests.py contenttypes_tests --parallel=1`

------
https://chatgpt.com/codex/tasks/task_e_68643ba0bf0c8322b632481c7e146e6a