### PR TITLE
Implement remote class CT lookup

### DIFF
--- a/federated_foreign_key/fields.py
+++ b/federated_foreign_key/fields.py
@@ -56,11 +56,17 @@ def get_remote_standin_class(content_type: GenericContentType):
             def __init__(self, ct: GenericContentType):
                 self.model_name = ct.model
                 self.app_label = ct.app_label
+                self.service = ct.project
 
         standin = type(
             name,
             (base,),
-            {"_meta": StandinMeta(content_type)},
+            {
+                "_meta": StandinMeta(content_type),
+                "get_content_type": classmethod(
+                    lambda cls: GenericContentType.objects.get_for_model(cls)
+                ),
+            },
         )
         _REMOTE_STANDIN_CACHE[key] = standin
     return standin

--- a/federated_foreign_key/models.py
+++ b/federated_foreign_key/models.py
@@ -46,7 +46,10 @@ class GenericContentTypeManager(django_models.Manager["GenericContentType"]):
 
     def _get_opts(self, model: Type[django_models.Model], for_concrete_model: bool) -> Options:
         """Return the ``Options`` object for ``model``."""
-        return model._meta.concrete_model._meta if for_concrete_model else model._meta
+        try:
+            return model._meta.concrete_model._meta if for_concrete_model else model._meta
+        except AttributeError:
+            return model._meta
 
     def get_for_model(
         self,
@@ -54,9 +57,18 @@ class GenericContentTypeManager(django_models.Manager["GenericContentType"]):
         for_concrete_model: bool = True,
         project: Optional[str] = None,
     ) -> "GenericContentType":
-        if project is None:
-            project = get_current_project_name()
-        opts = self._get_opts(model, for_concrete_model)
+        from .fields import get_remote_object_class
+
+        remote_base = get_remote_object_class()
+        model_cls = model if isinstance(model, type) else model.__class__
+        if issubclass(model_cls, remote_base) and not issubclass(model_cls, django_models.Model):
+            if project is None:
+                project = getattr(model_cls._meta, "service", get_current_project_name())
+            opts = model_cls._meta
+        else:
+            if project is None:
+                project = get_current_project_name()
+            opts = self._get_opts(model_cls, for_concrete_model)
         try:
             return self._get_from_cache(opts, project)
         except KeyError:
@@ -145,6 +157,10 @@ class GenericContentTypeManager(django_models.Manager["GenericContentType"]):
             ct = self.get(pk=id)
             self._add_to_cache(self.db, ct)
             return ct
+
+    def get_ct_from_type(self, model: type) -> "GenericContentType":
+        """Return the ``GenericContentType`` matching ``model``."""
+        return self.get_for_model(model)
 
 
 class GenericContentType(django_models.Model):

--- a/federated_foreign_key/models.py
+++ b/federated_foreign_key/models.py
@@ -158,9 +158,6 @@ class GenericContentTypeManager(django_models.Manager["GenericContentType"]):
             self._add_to_cache(self.db, ct)
             return ct
 
-    def get_ct_from_type(self, model: type) -> "GenericContentType":
-        """Return the ``GenericContentType`` matching ``model``."""
-        return self.get_for_model(model)
 
 
 class GenericContentType(django_models.Model):

--- a/federated_foreign_key/models.py
+++ b/federated_foreign_key/models.py
@@ -159,7 +159,6 @@ class GenericContentTypeManager(django_models.Manager["GenericContentType"]):
             return ct
 
 
-
 class GenericContentType(django_models.Model):
     """Like Django's ``ContentType`` model but scoped by project."""
 

--- a/tests/test_generic_contenttype.py
+++ b/tests/test_generic_contenttype.py
@@ -124,3 +124,28 @@ def test_model_class_remote_returns_standin():
     assert cls1 is cls2
     obj = ct.get_object_for_this_type(pk=5)
     assert isinstance(obj, cls1)
+
+
+def test_get_for_model_remote():
+    ct = GenericContentType.objects.create(
+        project="remote_proj4",
+        app_label="testapp",
+        model="book",
+    )
+
+    cls = ct.model_class()
+    assert cls._meta.service == "remote_proj4"
+
+    fetched = GenericContentType.objects.get_for_model(cls)
+    assert fetched == ct
+
+
+def test_remote_class_get_content_type():
+    ct = GenericContentType.objects.create(
+        project="remote_proj5",
+        app_label="testapp",
+        model="book",
+    )
+
+    cls = ct.model_class()
+    assert cls.get_content_type() == ct


### PR DESCRIPTION
## Summary
- support remote stand-ins with `get_for_model`
- store a `get_content_type()` classmethod on remote stand-ins
- expand tests for remote class lookups

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68654d40cdac8322a7f22a91c4a286e7