### PR TITLE
Fix repeated content_object prefetch

### DIFF
--- a/federated_foreign_key/fields.py
+++ b/federated_foreign_key/fields.py
@@ -57,6 +57,7 @@ def get_remote_standin_class(content_type: GenericContentType):
                 self.model_name = ct.model
                 self.app_label = ct.app_label
                 self.service = ct.project
+
                 class PK:
                     def get_prep_value(self, value):
                         return int(value)

--- a/federated_foreign_key/fields.py
+++ b/federated_foreign_key/fields.py
@@ -57,6 +57,14 @@ def get_remote_standin_class(content_type: GenericContentType):
                 self.model_name = ct.model
                 self.app_label = ct.app_label
                 self.service = ct.project
+                class PK:
+                    def get_prep_value(self, value):
+                        return int(value)
+
+                    def to_python(self, value):
+                        return int(value)
+
+                self.pk = PK()
 
         standin = type(
             name,
@@ -78,6 +86,11 @@ class RemoteObject:
     def __init__(self, content_type, object_id):
         self.content_type = content_type
         self.object_id = object_id
+
+    @property
+    def pk(self):
+        """Alias to :attr:`object_id` for compatibility with Django."""
+        return self.object_id
 
     def __repr__(self):
         return f"<RemoteObject {self.content_type} id={self.object_id}>"
@@ -162,8 +175,13 @@ class FederatedForeignKey(DjangoGenericForeignKey):
         if rel_obj is None and self.is_cached(instance):
             return rel_obj
         if rel_obj is not None:
-            ct_match = ct_id == self.get_content_type(obj=rel_obj).id
-            pk_match = ct_match and rel_obj.pk == pk_val
+            if hasattr(rel_obj, "content_type"):
+                rel_ct = rel_obj.content_type
+            else:
+                rel_ct = self.get_content_type(obj=rel_obj)
+            rel_pk = getattr(rel_obj, "pk", getattr(rel_obj, "object_id", None))
+            ct_match = ct_id == rel_ct.id
+            pk_match = ct_match and rel_pk == pk_val
             if pk_match:
                 return rel_obj
             else:

--- a/tests/test_federated_fk.py
+++ b/tests/test_federated_fk.py
@@ -105,3 +105,23 @@ def test_reverse_manager_create_and_get():
     updated, created = book.references.update_or_create(pk=ref.pk)
     assert not created
     assert updated == ref
+
+
+def test_prefetch_remote_content_object_twice():
+    ct = GenericContentType.objects.create(
+        project="remote_proj_twice",
+        app_label="testapp",
+        model="book",
+    )
+    Reference.objects.create(content_type=ct, object_id=1)
+
+    qs = Reference.objects.prefetch_related("content_object", "content_object")
+    result = list(qs)[0]
+    first = result.content_object
+    second = result.content_object
+
+    from federated_foreign_key.fields import RemoteObject
+
+    assert isinstance(first, RemoteObject)
+    assert first.object_id == 1
+    assert first is second

--- a/tests/test_federated_fk.py
+++ b/tests/test_federated_fk.py
@@ -129,6 +129,7 @@ def test_prefetch_remote_content_object_twice():
     assert first.object_id == 1
     assert first is second
 
+
 def test_prefetch_related_objects():
     """Prefetch ``content_object`` for local references only."""
     books = [Book.objects.create(title=f"Prefetch {i}") for i in range(5)]


### PR DESCRIPTION
## Summary
- add regression test for referencing `content_object` multiple times
- ensure RemoteObject mimics model pk field
- handle cached RemoteObject in FederatedForeignKey.__get__

## Testing
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6866779ad4d08322a3383ad53fba6834