### PR TITLE
Add hashing logic for RemoteObject

### DIFF
--- a/federated_foreign_key/fields.py
+++ b/federated_foreign_key/fields.py
@@ -96,6 +96,17 @@ class RemoteObject:
     def __repr__(self):
         return f"<RemoteObject {self.content_type} id={self.object_id}>"
 
+    def __eq__(self, other):
+        if not isinstance(other, RemoteObject):
+            return NotImplemented
+        return (
+            self.content_type == other.content_type
+            and self.object_id == other.object_id
+        )
+
+    def __hash__(self):
+        return hash((self.content_type, self.object_id))
+
 
 class FederatedForeignKey(DjangoGenericForeignKey):
     """A GenericForeignKey variant aware of project boundaries."""

--- a/tests/test_federated_fk.py
+++ b/tests/test_federated_fk.py
@@ -158,3 +158,21 @@ def test_prefetch_related_objects():
     assert local_objs == books
     assert isinstance(remote_obj, RemoteObject)
     assert remote_obj.object_id == 99
+
+
+def test_remote_object_hashing():
+    """Remote objects referencing the same item should hash equally."""
+    ct = GenericContentType.objects.create(
+        project="hash_proj",
+        app_label="testapp",
+        model="book",
+    )
+    refs = [
+        Reference.objects.create(content_type=ct, object_id=7)
+        for _ in range(5)
+    ]
+    objs = [r.content_object for r in refs]
+
+    # objects should compare equal and condense to a single entry in a set
+    assert len(set(objs)) == 1
+    assert all(o == objs[0] for o in objs)


### PR DESCRIPTION
## Summary
- implement `__eq__` and `__hash__` on `RemoteObject`
- add test ensuring remote objects with the same reference collapse into one when added to a set

## Testing
- `ruff check .`
- `flake8`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68668a4b22f08322a0316ac446817d99